### PR TITLE
Add generateOwnershipWallet for shallowly generating a wallet

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -328,6 +328,41 @@ const combine = shards => {
 }
 
 /**
+ * Generate just the ownership branch of an Urbit HD wallet given the
+ * provided configuration.
+ *
+ * Expects an object with the following properties:
+ *
+ * @param  {String}  ticket a 64, 128, or 384-bit @q master ticket
+ * @param  {Number}  ship a 32-bit Urbit ship number
+ * @param  {String}  passphrase an optional passphrase to use when deriving
+ *   seeds from BIP39 mnemonics
+ * @return  {Promise<Object>}
+ */
+const generateOwnershipWallet = async config => {
+  /* istanbul ignore next */
+  if ('ticket' in config === false) {
+    throw new Error('generateWallet: no ticket provided')
+  }
+  /* istanbul ignore next */
+  if ('ship' in config === false) {
+    throw new Error('generateWallet: no ship provided')
+  }
+
+  const { ticket, ship } = config
+  const passphrase = 'passphrase' in config ? config.passphrase : null
+
+  const buf = Buffer.from(ob.patq2hex(ticket), 'hex')
+  const masterSeed = await argon2u(buf, ship)
+
+  return deriveNode(
+    masterSeed,
+    CHILD_SEED_TYPES.OWNERSHIP,
+    passphrase
+  );
+}
+
+/**
  * Generate an Urbit HD wallet given the provided configuration.
  *
  * Expects an object with the following properties:
@@ -427,6 +462,7 @@ const generateWallet = async config => {
 
 module.exports = {
   generateWallet,
+  generateOwnershipWallet,
   deriveNode,
   deriveNodeSeed,
   deriveNodeKeys,

--- a/test/test.js
+++ b/test/test.js
@@ -415,6 +415,52 @@ describe('deriveNetworkSeed', () => {
 
 })
 
+describe('generateOwnershipWallet', () => {
+  it('generates wallets as expected', async function() {
+    this.timeout(20000)
+
+    let config = {
+      ticket: '~doznec-marbud',
+      ship: 1
+    }
+    let wallet = await kg.generateOwnershipWallet(config)
+    let expected = objectFromFile('./test/assets/wallet0.json')
+
+    expect(lodash.isEqual(wallet, expected.ownership)).to.equal(true)
+
+    config = {
+      ticket: '~marbud-tidsev-litsut-hidfep',
+      ship: 65012,
+      boot: true
+    }
+    wallet = await kg.generateOwnershipWallet(config)
+    expected = objectFromFile('./test/assets/wallet1.json')
+
+    expect(lodash.isEqual(wallet, expected.ownership)).to.equal(true)
+
+    config = {
+      ticket: '~wacfus-dabpex-danted-mosfep-pasrud-lavmer-nodtex-taslus-pactyp-milpub-pildeg-fornev-ralmed-dinfeb-fopbyr-sanbet-sovmyl-dozsut-mogsyx-mapwyc-sorrup-ricnec-marnys-lignex',
+      passphrase: 'froot loops',
+      ship: 222,
+      revision: 6
+    }
+    wallet = await kg.generateOwnershipWallet(config)
+    expected = objectFromFile('./test/assets/wallet2.json')
+
+    expect(lodash.isEqual(wallet, expected.ownership)).to.equal(true)
+
+    config = {
+      ticket: '~doznec-marbud',
+      ship: 0
+    }
+    wallet = await kg.generateOwnershipWallet(config)
+    expected = objectFromFile('./test/assets/wallet3.json')
+
+    expect(lodash.isEqual(wallet, expected.ownership)).to.equal(true)
+
+  })
+})
+
 describe('generateWallet', () => {
   it('generates wallets as expected', async function() {
     this.timeout(20000)


### PR DESCRIPTION
This is useful for the case where we _only_ care about the ownership wallet/address, such as when generating temporary wallets for invites and similar flows. This saves us some computation time on parts of the wallet we don't care about.