### PR TITLE
Fix browser field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3357,9 +3357,9 @@
       "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA=="
     },
     "urbit-ob": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/urbit-ob/-/urbit-ob-4.1.1.tgz",
-      "integrity": "sha512-YaUhzaGpFOHZoXr9qp8417kPkEcTlVdzrX+izGlwfLpWIwiSiCoI+0ZiPxgX+uDZmfQ2KqGEQxAS2BosDQne9Q==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/urbit-ob/-/urbit-ob-4.1.3.tgz",
+      "integrity": "sha512-5anp5suRAuYPBBTpa+BAVlNO5DPNR2mTNdiYRgl1QDngkVH/Xxs0oYbFPE6uGXmXiS8F9c9BXJAqzZgVu8C/jg==",
       "requires": {
         "bn.js": "^4.11.8",
         "lodash.chunk": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "urbit-key-generation",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Key derivation and HD wallet generation functions for Urbit.",
   "main": "src/index.js",
   "browser": {
-    "src/index.js": "dist/index.js"
+    "urbit-key-generation": "./dist/index.js"
   },
   "scripts": {
     "test": "nyc mocha --reporter spec test/test.js",
@@ -34,7 +34,7 @@
     "keccak": "^1.4.0",
     "secp256k1": "^3.5.2",
     "tweetnacl": "^1.0.0",
-    "urbit-ob": "4.1.1"
+    "urbit-ob": "4.1.3"
   },
   "devDependencies": {
     "browserify": "^16.2.3",

--- a/test/assets/wallet0.json
+++ b/test/assets/wallet0.json
@@ -2,7 +2,7 @@
  "meta": {
   "generator": {
    "name": "urbit-key-generation",
-   "version": "0.17.1"
+   "version": "0.17.2"
   },
   "spec": "UP8",
   "ship": 1,

--- a/test/assets/wallet1.json
+++ b/test/assets/wallet1.json
@@ -2,7 +2,7 @@
  "meta": {
   "generator": {
    "name": "urbit-key-generation",
-   "version": "0.17.1"
+   "version": "0.17.2"
   },
   "spec": "UP8",
   "ship": 65012,

--- a/test/assets/wallet2.json
+++ b/test/assets/wallet2.json
@@ -2,7 +2,7 @@
  "meta": {
   "generator": {
    "name": "urbit-key-generation",
-   "version": "0.17.1"
+   "version": "0.17.2"
   },
   "spec": "UP8",
   "ship": 222,

--- a/test/assets/wallet3.json
+++ b/test/assets/wallet3.json
@@ -2,7 +2,7 @@
  "meta": {
   "generator": {
    "name": "urbit-key-generation",
-   "version": "0.17.1"
+   "version": "0.17.2"
   },
   "spec": "UP8",
   "ship": 0,

--- a/test/assets/wallet4.json
+++ b/test/assets/wallet4.json
@@ -2,7 +2,7 @@
  "meta": {
   "generator": {
    "name": "urbit-key-generation",
-   "version": "0.17.1"
+   "version": "0.17.2"
   },
   "spec": "UP8",
   "ship": 16777215,


### PR DESCRIPTION
This in the same spirit of urbit/urbit-ob#30.  In this case browserify requires the `browser` field to specify the *module name*, `urbit-key-generation`, to replace.