### PR TITLE
Crash if buffers obtained from hex strings are the empty buffer

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -346,8 +346,8 @@ describe('deriveNetworkKeys', () => {
   })
 
   it('contains the expected fields', () => {
-    let prop = jsc.forall(jsc.string, str => {
-      let keys = kg.deriveNetworkKeys(Buffer.from(str))
+    let prop = jsc.forall(jsc.nat, int => {
+      let keys = kg.deriveNetworkKeys(int.toString(16))
 
       return 'auth' in keys && 'crypt' in keys
         && 'public' in keys.auth && 'private' in keys.auth
@@ -355,6 +355,15 @@ describe('deriveNetworkKeys', () => {
     })
 
     jsc.assert(prop, { tests: 50 })
+  })
+
+  it('crashes for invalid hex, but counts empty as valid', () => {
+    try {
+      kg.deriveNetworkKeys('invalid')
+    } catch(e) {
+      expect(e.message.slice(0, 18)).to.equal('invalid hex string')
+    }
+    kg.deriveNetworkKeys('')
   })
 })
 


### PR DESCRIPTION
`Buffer.from('invalid', 'hex')` would result in an empty buffer. Keygen would
happily proceed with this, hiding dangerously incorrect behavior.

This causes us to check for an empty buffer result, and crash if it's
unexpected. To avoid "pedantic" crashes, it strips leading `0x` and ensures
the hex string contains full bytes by left-padding with `0` if needed.

Fixes #84.