### PR TITLE
devex: add Typescript declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.20.1",
   "description": "Key derivation and HD wallet generation functions for Urbit.",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "browser": {
     "urbit-key-generation": "./dist/index.js"
   },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,15 +23,13 @@ interface WalletNode {
   derivationPath: string;
 }
 
+interface BitcoinWallet extends WalletNode {}
+
 interface WalletConfig {
   ticket: string;
   ship: number;
   passphrase?: string;
   boot?: boolean;
-}
-
-interface BitcoinWallet {
-  
 }
 
 interface UrbitWallet {
@@ -64,7 +62,20 @@ interface UrbitWallet {
 }
 
 declare module 'urbit-key-generation' {
+  function combine(shards: string[]): string;
   function deriveNetworkKeys(hex: string): NetworkKeys;
+  function deriveNetworkSeed(
+    mnemonic: string,
+    passphrase: string,
+    revision: number
+  ): string;
+  function generateCode (pair: NetworkKeys, step: number): string; 
+  function generateKeyfile(pair: NetworkKeys, point: number, revision: number): string;
+  function generateOwnershipWallet({
+    ticket,
+    ship,
+    passphrase,
+  }: WalletConfig): UrbitWallet;
   function generateWallet({
     ticket,
     ship,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,18 @@
+type ValueOf<T> = T[keyof T];
+
+type CHILD_SEED_TYPES = {
+  OWNERSHIP: 'ownership',
+  TRANSFER: 'transfer',
+  SPAWN: 'spawn',
+  VOTING: 'voting',
+  MANAGEMENT: 'management',
+  NETWORK: 'network',
+  BITCOIN_MAINNET: 'bitcoinMainnet',
+  BITCOIN_TESTNET: 'bitcoinTestnet',
+}
+
+type ChildSeedType = ValueOf<CHILD_SEED_TYPES>;
+
 interface NetworkKeys {
   crypt: {
     private: string;
@@ -23,7 +38,7 @@ interface WalletNode {
   derivationPath: string;
 }
 
-interface BitcoinWallet extends WalletNode {}
+interface BitcoinWallet extends WalletNode { }
 
 interface WalletConfig {
   ticket: string;
@@ -49,12 +64,12 @@ interface UrbitWallet {
   management: WalletNode;
   transfer: WalletNode;
   network:
-    | {
-        type: string;
-        seed: string;
-        keys: string;
-      }
-    | {};
+  | {
+    type: string;
+    seed: string;
+    keys: string;
+  }
+  | {};
   voting?: WalletNode;
   spawn?: WalletNode;
   bitcoinTestnet: BitcoinWallet;
@@ -62,14 +77,21 @@ interface UrbitWallet {
 }
 
 declare module 'urbit-key-generation' {
+  const CHILD_SEED_TYPES: CHILD_SEED_TYPES;
+  function addressFromSecp256k1Public(pub: string): string;
+  function argon2u(entropy: Buffer, ship: number): Promise<Uint8Array>;
   function combine(shards: string[]): string;
+  function deriveNetworkInfo(mnemonic: string, revision: number, passphrase?: string): { type: 'network', seed: string, keys: WalletNodeKeys };
   function deriveNetworkKeys(hex: string): NetworkKeys;
   function deriveNetworkSeed(
     mnemonic: string,
     passphrase: string,
     revision: number
   ): string;
-  function generateCode (pair: NetworkKeys, step: number): string; 
+  function deriveNode(master: Uint8Array, type: ChildSeedType, derivationPath: string, passphrase?: string): WalletNode;
+  function deriveNodeKeys(mnemonic: string, derivationPath: string, passphrase?: string): WalletNodeKeys;
+  function deriveNodeSeed(master: Uint8Array, type: ChildSeedType): string;
+  function generateCode(pair: NetworkKeys, step: number): string;
   function generateKeyfile(pair: NetworkKeys, point: number, revision: number): string;
   function generateOwnershipWallet({
     ticket,
@@ -82,4 +104,5 @@ declare module 'urbit-key-generation' {
     passphrase,
     boot,
   }: WalletConfig): UrbitWallet;
+  function shard(ticket: string): string[];
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,74 @@
+interface NetworkKeys {
+  crypt: {
+    private: string;
+    public: string;
+  };
+  auth: {
+    private: string;
+    public: string;
+  };
+}
+
+interface WalletNodeKeys {
+  public: string;
+  private: string;
+  chain: string;
+  address: string;
+}
+
+interface WalletNode {
+  type: string;
+  seed: string;
+  keys: WalletNodeKeys;
+  derivationPath: string;
+}
+
+interface WalletConfig {
+  ticket: string;
+  ship: number;
+  passphrase?: string;
+  boot?: boolean;
+}
+
+interface BitcoinWallet {
+  
+}
+
+interface UrbitWallet {
+  meta: {
+    generator: {
+      name: string;
+      version: string;
+    };
+    spec: string;
+    ship: string;
+    patp: string;
+    tier: string;
+    passphrase: string;
+  };
+  masterSeed: string;
+  ownership: WalletNode;
+  management: WalletNode;
+  transfer: WalletNode;
+  network:
+    | {
+        type: string;
+        seed: string;
+        keys: string;
+      }
+    | {};
+  voting?: WalletNode;
+  spawn?: WalletNode;
+  bitcoinTestnet: BitcoinWallet;
+  bitcoinMainnet: BitcoinWallet;
+}
+
+declare module 'urbit-key-generation' {
+  function deriveNetworkKeys(hex: string): NetworkKeys;
+  function generateWallet({
+    ticket,
+    ship,
+    passphrase,
+    boot,
+  }: WalletConfig): UrbitWallet;
+}


### PR DESCRIPTION
# Context

While refactoring Network Key generation in Bridge, I created a declaration file that covered some of these functions. Eventually I had time to add the rest, and now would like to upstream it for other developers.

# Changes

This PR adds Typescript declarations for all public  `urbit-key-generation` module [exports](https://github.com/urbit/urbit-key-generation/blob/master/src/index.js#L739):
  - `addressFromSecp256k1Public`
  - `argon2u`
  - `CHILD_SEED_TYPES`
  - `combine`
  - `deriveNetworkInfo`
  - `deriveNetworkKeys`
  - `deriveNetworkSeed`
  - `deriveNode`
  - `deriveNodeKeys`
  - `deriveNodeSeed`
  - `generateCode`
  - `generateKeyfile`
  - `generateOwnershipWallet`
  - `generateWallet`
  - `shard`